### PR TITLE
fix template call to prevent recursive display of latest news

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ og_description: "The Society for Early English & Norse Electronic Texts (SEENET)
   <h1>Latest News</h1>
   <article>
     <h1>{{ site.posts.first.title }}</h1>
-    {{ site.posts.first }}
+    {{ site.posts.first.content }}
   </article?
 </section>
 <section>


### PR DESCRIPTION
Main page template was incorrectly calling whole post rather than post content for latest news, which caused recursion of site navigation. This PR corrects by specifying that the content is what is to be included in the template.